### PR TITLE
Browser compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -47,8 +47,3 @@ KP.prototype.store = function (value, opts) {
 }
 
 KP.verify = ed.verify
-
-function tobuf (s) {
-  if (typeof s === 'string') return Buffer(s, 'hex')
-  return s
-}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "sha.js": "^2.4.2"
   },
   "devDependencies": {
+    "bittorrent-dht": "^7.6.0",
     "tape": "^4.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bittorrent-dht-store-keypair",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "create and load signing keys for bittorrent-dht dht_store",
   "main": "index.js",
   "directories": {
@@ -8,15 +8,20 @@
     "test": "test"
   },
   "dependencies": {
-    "defined": "^1.0.0",
-    "ed25519-supercop": "^1.0.0",
-    "sha.js": "^2.4.2"
+    "jssha": "^2.3.1",
+    "supercop.wasm": "^3.0.1"
   },
   "devDependencies": {
     "bittorrent-dht": "^7.6.0",
-    "tape": "^4.2.0"
+    "browserify": "^14.4.0",
+    "tape": "^4.2.0",
+    "uglifyjs": "^2.4.11"
   },
   "scripts": {
+    "build": "npm run prepare && npm run build-browser && npm run uglify",
+    "prepare": "rm -r dist && mkdir dist",
+    "build-browser": "browserify -s bittorrent_dht_store_keypair -o dist/index.browser.js index.js && cp node_modules/supercop.wasm/supercop.wasm dist/",
+    "uglify": "uglifyjs dist/index.browser.js > dist/index.browser.min.js",
     "test": "tape test/*.js"
   },
   "repository": {
@@ -37,5 +42,8 @@
   "bugs": {
     "url": "https://github.com/substack/bittorrent-dht-store-keypair/issues"
   },
-  "homepage": "https://github.com/substack/bittorrent-dht-store-keypair#readme"
+  "homepage": "https://github.com/substack/bittorrent-dht-store-keypair#readme",
+  "jspm": {
+    "main": "index.browser.js"
+  }
 }

--- a/test/dht.js
+++ b/test/dht.js
@@ -4,7 +4,6 @@ var KP = require('../')
 
 test('dht hex keys', function (t) {
   t.plan(3)
-  var value = new Buffer(200).fill('abc')
   var dht0 = new DHT({ bootstrap: false, verify: KP.verify })
   var dht1 = new DHT({ bootstrap: false, verify: KP.verify })
   var kp0 = new KP({
@@ -18,10 +17,12 @@ test('dht hex keys', function (t) {
   })
 
   dht0.listen(function () {
-    dht1.addNode('127.0.0.1:' + dht0._port)
+    dht1.addNode({host: '127.0.0.1', port: dht0.address().port})
     dht1.once('node', function () {
-      dht0.put(kp0.store('wow'), function (errors, hash) {
-        errors.forEach(t.error)
+      dht0.put(kp0.store('wow'), function (error, hash) {
+        if (error) {
+          t.fail(error.message)
+        }
         t.equal(
           hash.toString('hex'),
           'f3f10aff933ed0b79bdbf3de21fe426f482f14fc'
@@ -37,7 +38,6 @@ test('dht hex keys', function (t) {
 
 test('dht generated key', function (t) {
   t.plan(2)
-  var value = new Buffer(200).fill('abc')
   var dht0 = new DHT({ bootstrap: false, verify: KP.verify })
   var dht1 = new DHT({ bootstrap: false, verify: KP.verify })
   var kp0 = new KP
@@ -47,10 +47,12 @@ test('dht generated key', function (t) {
   })
 
   dht0.listen(function () {
-    dht1.addNode('127.0.0.1:' + dht0._port)
+    dht1.addNode({host: '127.0.0.1', port: dht0.address().port})
     dht1.once('node', function () {
-      dht0.put(kp0.store('wow'), function (errors, hash) {
-        errors.forEach(t.error)
+      dht0.put(kp0.store('wow'), function (error, hash) {
+        if (error) {
+          t.fail(error.message)
+        }
         dht1.get(hash, function (err, node) {
           t.ifError(err)
           t.equal(node.v.toString(), 'wow')

--- a/test/gen_sign_verify.js
+++ b/test/gen_sign_verify.js
@@ -1,16 +1,16 @@
 var test = require('tape')
 var KP = require('../')
-var ed = require('ed25519-supercop')
+var ed = require('supercop.wasm')
 
 test('generate, sign, verify', function (t) {
   t.plan(4)
   var kp = new KP()
-  var msg = 'whatever'
+  var msg = Buffer.from('whatever')
   var sig = kp.sign(msg)
   var xsig = xmod(sig)
   var xmsg = xmod(msg)
   var xpk = xmod(kp.publicKey)
- 
+
   t.ok(ed.verify(sig, msg, kp.publicKey))
   t.notOk(ed.verify(xsig, msg, kp.publicKey))
   t.notOk(ed.verify(sig, xmsg, kp.publicKey))


### PR DESCRIPTION
This PR is based on #4, which is why 2 commits.

Commit message explains everything, but in short this allows `bittorrent-dht-store-keypair` to be used in browser, namely with https://github.com/nazar-pc/webtorrent-dht

Also I didn't add `dist` directory to commit message (let me know it you'd like me to do so, published NPM package should contain it).

Would be nice if you can review this PR quickly to identify if you're going to accept it or I have to maintain yet another fork.